### PR TITLE
Share dates calculation logic

### DIFF
--- a/common.mjs
+++ b/common.mjs
@@ -65,3 +65,43 @@ export function generateCalendarMatrix(year, month) {
 
   return weeks;
 }
+
+//Get the date (day number) of the nth weekday in a given month.
+
+export function getNthWeekdayOfMonth(year, month, weekdayName, occurrence) {
+  const weekdayNames = [
+    "Monday",
+    "Tuesday",
+    "Wednesday",
+    "Thursday",
+    "Friday",
+    "Saturday",
+    "Sunday",
+  ];
+  const weekday = weekdayNames.indexOf(weekdayName);
+  if (weekday === -1) throw new Error(`Invalid weekday name: ${weekdayName}`);
+
+  const daysInMonth = getDaysInMonth(year, month);
+  const days = [];
+
+  for (let d = 1; d <= daysInMonth; d++) {
+    const date = new Date(year, month - 1, d);
+    const jsWeekday = (date.getDay() + 6) % 7; // Monday=0
+    if (jsWeekday === weekday) days.push(d);
+  }
+
+  switch (occurrence?.toLowerCase()) {
+    case "first":
+      return days[0];
+    case "second":
+      return days[1];
+    case "third":
+      return days[2];
+    case "fourth":
+      return days[3];
+    case "last":
+      return days[days.length - 1];
+    default:
+      return null;
+  }
+}

--- a/generate-ical.mjs
+++ b/generate-ical.mjs
@@ -3,31 +3,7 @@
 
 import fs from "fs";
 import daysData from "./days.json" with { type: "json" };
-
-// --- Helper: Get nth weekday of a given month ---
-function getNthWeekdayOfMonth(year, month, weekdayName, occurrence) {
-  const weekdayNames = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"];
-  const weekday = weekdayNames.indexOf(weekdayName);
-  if (weekday === -1) throw new Error(`Invalid weekday name: ${weekdayName}`);
-
-  const daysInMonth = new Date(year, month, 0).getDate();
-  const days = [];
-
-  for (let d = 1; d <= daysInMonth; d++) {
-    const date = new Date(year, month - 1, d);
-    const jsWeekday = (date.getDay() + 6) % 7; // Monday=0
-    if (jsWeekday === weekday) days.push(d);
-  }
-
-  switch (occurrence?.toLowerCase()) {
-    case "first": return days[0];
-    case "second": return days[1];
-    case "third": return days[2];
-    case "fourth": return days[3];
-    case "last": return days[days.length - 1];
-    default: return null;
-  }
-}
+import { getNthWeekdayOfMonth } from "./common.mjs";
 
 // --- Helper: convert Date to YYYYMMDD ---
 function formatDateYYYYMMDD(date) {

--- a/web.mjs
+++ b/web.mjs
@@ -1,4 +1,4 @@
-import { generateCalendarMatrix } from "./common.mjs";
+import { generateCalendarMatrix, getNthWeekdayOfMonth } from "./common.mjs";
 import daysData from "../days.json" with { type: "json" };
 
 window.onload = function() {
@@ -63,30 +63,6 @@ window.onload = function() {
   controlsDiv.appendChild(yearLabel);
   controlsDiv.appendChild(yearSelect);
   controlsDiv.appendChild(nextBtn);
-
-// --- Get nth weekday of month ---
-  function getNthWeekdayOfMonth(year, month, weekdayName, occurrence) {
-    const weekdayNames = ["Monday","Tuesday","Wednesday","Thursday","Friday","Saturday","Sunday"];
-    const weekday = weekdayNames.indexOf(weekdayName);
-
-    const daysInMonth = new Date(year, month, 0).getDate();
-    const days = [];
-
-    for (let d = 1; d <= daysInMonth; d++) {
-      const day = new Date(year, month - 1, d);
-      const jsWeekday = (day.getDay() + 6) % 7; // Monday=0
-      if (jsWeekday === weekday) days.push(d);
-    }
-
-    switch (occurrence.toLowerCase()) {
-      case "first": return days[0];
-      case "second": return days[1];
-      case "third": return days[2];
-      case "fourth": return days[3];
-      case "last": return days[days.length - 1];
-      default: return null;
-    }
-  }
 
   // --- Calendar rendering function ---
   function renderCalendar(year, month) {


### PR DESCRIPTION
- transfer function 'getNthWeekdayOfMonth' to common.mjs
- import 'getNthWeekdayOfMonth' in web.mjs from common.mjs
- import 'getNthWeekdayOfMonth' in generate-ical.mjs from common.mjs
- Logic for calculating dates is now shared between the web generator and the iCal generator.